### PR TITLE
sovle deploying to github-pages failed issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
           npm run export
 
       - name: Install SSH Client
-        uses: webfactory/ssh-agent@v0.2.0
+        uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

`webfactory/ssh-agent` v0.4.1 fixed this issue.