### PR TITLE
disable nextjs telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
+    "postinstall": "next telemetry disable",
     "dev": "next",
     "build": "next build",
     "export": "next export",


### PR DESCRIPTION
Stop share any data to anyone. So we disbale next telemetry service after installed all dependency packges.